### PR TITLE
Implement wait_for_db logic with refactor and fixes

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -11,11 +11,11 @@ ALLOWED_HOSTS = ["*"]
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': config('DB_NAME'),
-        'USER': config('DB_USER'),
-        'PASSWORD': config('DB_PASSWORD'),
-        'HOST': config('DB_HOST'),
-        'PORT': config('DB_PORT'),
+        'NAME': config('DB_NAME', 'postgres'),
+        'USER': config('DB_USER', 'postgres'),
+        'PASSWORD': config('DB_PASSWORD', ''),
+        'HOST': config('DB_HOST', 'localhost'),
+        'PORT': config('DB_PORT', 5432),
     }
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+export PYTHONPATH=$PYTHONPATH:/app
+
+echo "Waiting for database..."
+python scripts/wait_for_db.py
+
 echo "Running Database Migrations"
 python manage.py migrate
 
@@ -11,7 +16,7 @@ if [ "$DJANGO_ENV" = "prod" ]; then
 fi
 
 echo "Seeding data (countries, cities)..."
-python seed_data.py || { echo "Data seeding failed"; exit 1; }
+python scripts/seed_data.py || { echo "Data seeding failed"; exit 1; }
 
 echo "Running server..."
 python manage.py runserver 0.0.0.0:8000

--- a/scripts/seed_data.py
+++ b/scripts/seed_data.py
@@ -2,7 +2,7 @@ import os
 import django
 
 # Update this if your settings module path is different!
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.local')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
 django.setup()
 
 from api.core.models import Country, City

--- a/scripts/wait_for_db.py
+++ b/scripts/wait_for_db.py
@@ -1,0 +1,43 @@
+import os
+import time
+import django
+
+from django.db import connections
+from django.db.utils import OperationalError
+from django.conf import settings
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+django.setup()
+
+db_config = settings.DATABASES['default']
+
+MAX_RETRIES = 30
+RETRY_DELAY = 1
+
+
+def check_database_connection():
+    try:
+        connection = connections['default']
+        connection.ensure_connection()
+        return True
+    except OperationalError:
+        return False
+
+
+def wait_for_db():
+    retries = 0
+    while retries < MAX_RETRIES:
+        if check_database_connection():
+            print('Database is ready.')
+            break
+        else:
+            retries += 1
+            print(f'Database is unavailable - waiting {RETRY_DELAY} second(s)... Attempt {retries}/{MAX_RETRIES}')
+            time.sleep(RETRY_DELAY)
+    else:
+        print(f'Max retries reached. Could not connect to the database after {MAX_RETRIES} attempts.')
+        exit(1)
+
+
+if __name__ == '__main__':
+    wait_for_db()


### PR DESCRIPTION
This PR introduces a `wait_for_db.py` script to ensure the application waits for the database to become available before executing migrations and other startup logic.  
**Fixes #10**

### Changes

#### Database readiness (primary focus)
- Added `scripts/wait_for_db.py` to poll the database until it's reachable.
- Integrated the wait logic into `entrypoint.sh` before running `migrate`.

#### Script organization
- All custom startup-related .py scripts are now placed under scripts/ for better structure and maintainability.

#### Production settings improvement
- In `config/settings/prod.py`, added default fallbacks for database environment variables.
- Removed hardcoded `DJANGO_SETTINGS_MODULE` from `seed_data.py` to rely on external configuration.

---