### PR TITLE
Fix ImproperlyConfigured in seed_data.py

### DIFF
--- a/scripts/seed_data.py
+++ b/scripts/seed_data.py
@@ -1,11 +1,12 @@
 import os
 import django
 
-from api.core.models import Country, City
-
 # Update this if your settings module path is different!
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
 django.setup()
+
+from api.core.models import Country, City  # noqa E403
+
 
 # --- YOU CAN EDIT THIS DATA ---
 COUNTRIES = [


### PR DESCRIPTION
- Moved the import of `Country` and `City` models after `django.setup()`
- Added `# noqa E403` to suppress the flake8 warning for non-top-level imports

Fixes #14 